### PR TITLE
#9: typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ assert expect()s (or propogate errors).
 
 jasminePit.install(window);
 
-describe('MyTestSuite', functtion() {
+describe('MyTestSuite', function() {
   pit('Spec 1', function() {
     return funcThatReturnsPromise().then(function(stuff) {
       expect(stuff).toBe(stuff_i_expect_it_to_be);


### PR DESCRIPTION
Looks like `functtion` is supposed to be `function`.

Related issue: https://github.com/jeffmo/jasmine-pit/issues/9
