### PR TITLE
Add support for jasmine 2.2.x

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+max_line_length = 80
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = 0
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea
+node_modules
+
+npm-debug.log

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,7 @@
+{
+  "undef": true,
+  "unused": true,
+  "eqeqeq": true,
+  "node": true,
+  "jasmine": true
+}

--- a/index.js
+++ b/index.js
@@ -22,14 +22,16 @@
       promise && typeof promise.then === 'function');
   }
 
-  function wrapPromiseLegacyJasmine(promiseFn) {
+  function wrapPromiseLegacyJasmine(env, promiseFn) {
     return function () {
       var error = null;
       var isFinished = false;
 
-      runs(function () {
+      var currentSpec = env.currentSpec;
+
+      currentSpec.runs(function () {
         try {
-          var promise = promiseFn();
+          var promise = promiseFn.call(currentSpec);
 
           assertPromise(promise);
 
@@ -45,11 +47,11 @@
         }
       });
 
-      waitsFor(function () {
+      currentSpec.waitsFor(function () {
         return isFinished;
       });
 
-      runs(function () {
+      currentSpec.runs(function () {
         if (error) throw error;
       });
     };
@@ -87,7 +89,7 @@
 
     var env = jasmine.getEnv();
     var isLegacyJasmine = jasmine.version_ && jasmine.version_.major === 1;
-    var wrapFn = isLegacyJasmine ? wrapPromiseLegacyJasmine : wrapPromiseJasmine;
+    var wrapFn = isLegacyJasmine ? wrapPromiseLegacyJasmine.bind(null, env) : wrapPromiseJasmine;
 
     globalObject.pit = function pit(specName, promiseFn) {
       return env.it(specName, wrapFn(promiseFn));

--- a/index.js
+++ b/index.js
@@ -60,21 +60,18 @@
   function wrapPromiseJasmine(promiseFn) {
     return function (done) {
       var promise = promiseFn();
+      var fail = done.fail ? done.fail : function (err) { throw err; };
 
       try {
         assertPromise(promise);
-      } catch (e) {
-        done.fail(e);
+      } catch (err) {
+        fail(err);
       }
 
       promise.then(function (res) {
         done(res);
       })['catch'](function (err) {
-        if (done.fail) {
-          done.fail(err);
-        } else {
-          done(expect(err).toBeNull());
-        }
+        fail(err);
       });
     };
   }

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@
     };
 
     if (isLegacyJasmine) {
-      globalObject.pit.only = function pitOnly(specName, promiseFn) { // TODO: add note for jasmine-only
+      globalObject.pit.only = function pitOnly(specName, promiseFn) {
         return env.it.only(specName, wrapFn(promiseFn));
       };
     } else {

--- a/index.js
+++ b/index.js
@@ -68,7 +68,11 @@
       promise.then(function (res) {
         done(res);
       })['catch'](function (err) {
-        done.fail(err);
+        if (done.fail) {
+          done.fail(err);
+        } else {
+          done(expect(err).toBeNull());
+        }
       });
     };
   }

--- a/index.js
+++ b/index.js
@@ -1,53 +1,110 @@
-function install(globalObject) {
-  if (!globalObject.jasmine) {
-    throw new Error(
-      'It looks like you\'re trying to install jasmine-pit before installing ' +
-      'jasmine! Make sure there is a `jasmine` property on the global object ' +
-      '(window/global/etc) before calling install().'
-    );
+/* global define */
+
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define([], function () {
+      return (root.jasminePit = factory());
+    });
+  } else if (typeof exports === 'object') {
+    module.exports = factory();
+  } else {
+    root.jasminePit = factory();
+  }
+}(this, function () {
+  function assert(desc, test) {
+    if (!test) {
+      throw new Error(desc);
+    }
   }
 
-  var jasmine = globalObject.jasmine;
+  function assertPromise(promise) {
+    assert('pit() tests should return a promise',
+      promise && typeof promise.then === 'function');
+  }
 
-  globalObject.pit = function pit(specName, promiseBuilder) {
-    return jasmine.getEnv().it(specName, runPitTest.bind(null, promiseBuilder));
-  };
+  function wrapPromiseLegacyJasmine(promiseFn) {
+    return function () {
+      var error = null;
+      var isFinished = false;
 
-  globalObject.pit.only = function pitOnly(specName, promiseBuilder) {
-    return jasmine.getEnv().it.only(specName, runPitTest.bind(null, promiseBuilder));
-  };
+      runs(function () {
+        try {
+          var promise = promiseFn();
 
-  globalObject.xpit = function xpit(specName, promiseBuilder) {
-    return jasmine.getEnv().xit(specName, runPitTest.bind(null, promiseBuilder));
-  };
+          assertPromise(promise);
 
-  function runPitTest(promiseBuilder) {
-    var jasmineEnv = jasmine.getEnv();
-    var spec = jasmineEnv.currentSpec;
-    var isFinished = false;
-    var error = null;
-
-    spec.runs(function() {
-      try {
-        var promise = promiseBuilder.call(spec);
-        if (!promise || !promise.then) {
-          throw new Error('pit() tests should return a promise');
-        }
-
-        promise.then(function() {
+          promise.then(function () {
+            isFinished = true;
+          })['catch'](function (err) {
+            error = err;
+            isFinished = true;
+          });
+        } catch (e) {
+          error = e;
           isFinished = true;
-        })['catch'](function(err) {
-          error = err; isFinished = true;
-        });
+        }
+      });
+
+      waitsFor(function () {
+        return isFinished;
+      });
+
+      runs(function () {
+        if (error) throw error;
+      });
+    };
+  }
+
+  function wrapPromiseJasmine(promiseFn) {
+    return function (done) {
+      var promise = promiseFn();
+
+      try {
+        assertPromise(promise);
       } catch (e) {
-        error = e;
-        isFinished = true;
+        done.fail(e);
       }
-    });
 
-    spec.waitsFor(function() { return isFinished; });
-    spec.runs(function() { if (error) throw error; });
+      promise.then(function (res) {
+        done(res);
+      })['catch'](function (err) {
+        done.fail(err);
+      });
+    };
+  }
+
+  function install(globalObject) {
+    var jasmine = globalObject.jasmine;
+
+    assert(
+      'It looks like you\'re trying to install jasmine-pit before installing ' +
+      'jasmine! Make sure there is a `jasmine` property on the global object ' +
+      '(window/global/etc) before calling install().', jasmine);
+
+    var env = jasmine.getEnv();
+    var isLegacyJasmine = jasmine.version_ && jasmine.version_.major === 1;
+    var wrapFn = isLegacyJasmine ? wrapPromiseLegacyJasmine : wrapPromiseJasmine;
+
+    globalObject.pit = function pit(specName, promiseFn) {
+      return env.it(specName, wrapFn(promiseFn));
+    };
+
+    globalObject.xpit = function xpit(specName, promiseFn) {
+      return env.xit(specName, wrapFn(promiseFn));
+    };
+
+    if (isLegacyJasmine) {
+      globalObject.pit.only = function pitOnly(specName, promiseFn) { // TODO: add note for jasmine-only
+        return env.it.only(specName, wrapFn(promiseFn));
+      };
+    } else {
+      globalObject.fpit = function fpit(desc, promiseFn) {
+        return env.fit(desc, wrapFn(promiseFn));
+      };
+    }
+  }
+
+  return {
+    install: install
   };
-}
-
-exports.install = install;
+}));

--- a/package.json
+++ b/package.json
@@ -13,10 +13,14 @@
     "url": "git@github.com:jeffmo/jasmine-pit.git"
   },
   "scripts": {
-    "test": "jasmine"
+    "test-on-jasmine-1.x": "minijasminenode ./spec/jasmine-pit-spec.js ./spec/jasmine-1.x-specific-spec.js",
+    "test-on-jasmine-2.x": "minijasminenode2 ./spec/jasmine-pit-spec.js ./spec/jasmine-2.x-specific-spec.js",
+    "test": "npm run test-on-jasmine-1.x && npm run test-on-jasmine-2.x"
   },
   "license": "MIT",
   "devDependencies": {
-    "jasmine": "^2.2.1"
+    "minijasminenode": "^1.1.1",
+    "minijasminenode2": "^1.0.0",
+    "rsvp": "^3.0.18"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
     "minijasminenode": "^1.1.1",
     "minijasminenode2": "^1.0.0",
     "rsvp": "^3.0.18"
+  },
+  "dependencies": {
+    "jasmine-only": "^0.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,5 +12,11 @@
     "type": "git",
     "url": "git@github.com:jeffmo/jasmine-pit.git"
   },
-  "license": "MIT"
+  "scripts": {
+    "test": "jasmine"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "jasmine": "^2.2.1"
+  }
 }

--- a/spec/jasmine-1.x-specific-spec.js
+++ b/spec/jasmine-1.x-specific-spec.js
@@ -1,0 +1,9 @@
+var jasminePit = require('../index');
+
+jasminePit.install(global);
+
+describe('jasminePit should work on Jasmine 1.x: ', function () {
+  it('should have `pit.only` on globalObject', function () {
+    expect(global.pit.only).toBeDefined();
+  });
+});

--- a/spec/jasmine-2.x-specific-spec.js
+++ b/spec/jasmine-2.x-specific-spec.js
@@ -1,0 +1,9 @@
+var jasminePit = require('../index');
+
+jasminePit.install(global);
+
+describe('jasminePit should work on Jasmine 2.x: ', function () {
+  it('should have `fpit` on globalObject', function () {
+    expect(global.fpit).toBeDefined();
+  });
+});

--- a/spec/jasmine-pit-spec.js
+++ b/spec/jasmine-pit-spec.js
@@ -1,20 +1,27 @@
-/* global pit */
+/* global pit, xpit */
 
+var RSVP = require('rsvp');
 var jasminePit = require('../index');
 
 jasminePit.install(global);
 
-describe('JasminePit: ', function () {
+describe('jasminePit: ', function () {
   it('should have `pit`, `xpit` on globalObject', function () {
     expect(global.pit).toBeDefined();
     expect(global.xpit).toBeDefined();
   });
 
-  describe('Jasmine 1.x specific', function () {});
-
-  describe('Jasmine 2.x specific', function () {
-    it('should have `fpit` on globalObject', function () {
-      expect(global.fpit).toBeDefined();
+  pit('should work with Promise', function () {
+    return RSVP.resolve(42).then(function(val) {
+      expect(val).toBe(42);
     });
+  });
+
+  pit('should fail if Promise fails', function () {
+    return RSVP.reject(null);
+  });
+
+  xpit('should skip tests with `xpit`', function () {
+    throw Error; // should not happen
   });
 });

--- a/spec/jasmine-pit-spec.js
+++ b/spec/jasmine-pit-spec.js
@@ -1,0 +1,20 @@
+/* global pit */
+
+var jasminePit = require('../index');
+
+jasminePit.install(global);
+
+describe('JasminePit: ', function () {
+  it('should have `pit`, `xpit` on globalObject', function () {
+    expect(global.pit).toBeDefined();
+    expect(global.xpit).toBeDefined();
+  });
+
+  describe('Jasmine 1.x specific', function () {});
+
+  describe('Jasmine 2.x specific', function () {
+    it('should have `fpit` on globalObject', function () {
+      expect(global.fpit).toBeDefined();
+    });
+  });
+});

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,9 +1,0 @@
-{
-  "spec_dir": "spec",
-  "spec_files": [
-    "**/*[sS]pec.js"
-  ],
-  "helpers": [
-    "helpers/**/*.js"
-  ]
-}

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,9 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ]
+}


### PR DESCRIPTION
Good day.

I'm working on patch for `jest` to allow usage of jasmine 2.x. This patch makes it possible, because there where some changes in async support.

I've also added UMD definiton.

Please check the code.

TODOs:
- [x] consider multi jasmine versions tests
- [ ] add a note about jasmine-only (May be we should declare it as a dependency?)

P.S. I haven't tested it for `jasmine-1.x`
